### PR TITLE
Fix incorrect usage of the LLVM12 extension

### DIFF
--- a/org.kde.kdevelop.json
+++ b/org.kde.kdevelop.json
@@ -2,12 +2,6 @@
     "id": "org.kde.kdevelop",
     "runtime": "org.kde.Sdk",
     "runtime-version": "5.15-21.08",
-    "add-extensions": {
-        "org.freedesktop.Sdk.Extension.llvm12": {
-            "directory": "/usr/lib/sdk/llvm12",
-            "version": "21.08"
-        }
-    },
     "base": "io.qt.qtwebengine.BaseApp",
     "base-version": "5.15-21.08",
     "sdk": "org.kde.Sdk",


### PR DESCRIPTION
This needs further work to enable KDevelop to effectively use this
extension but this should at least fix the current issue.

See: https://github.com/flathub/org.freedesktop.Sdk.Extension.llvm12/issues/16
Fixes: https://github.com/flathub/org.kde.kdevelop/issues/9