### PR TITLE
xcd: track correct boost version

### DIFF
--- a/org.kde.kdevelop.json
+++ b/org.kde.kdevelop.json
@@ -142,7 +142,7 @@
                         "type": "anitya",
                         "project-id": 6845,
                         "stable-only": true,
-                        "url-template": "https://archives.boost.io/release/$version/source/boost_${major}_${minor}_$patch.tar.bz2"
+                        "url-template": "https://archives.boost.io/release/${major}.${minor}.${patch}/source/boost_${major}_${minor}_$patch.tar.bz2"
                     }
                 }
             ]


### PR DESCRIPTION
seems like upstream uses the -patch suffix now
